### PR TITLE
Feature - Fishing Level Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ creatures:
 
 Field notes:
 - `weight`: relative weight in random selection; higher = more common.
+- `min-level`: minimum fishing level to fish up sea creature. 
 - `potion-effects`: `EFFECT:AMPLIFIER:DURATION_TICKS` (e.g. `SPEED:1:600`).
 - `equipment`: keys are one of `HAND, OFF_HAND, HEAD, CHEST, LEGS, FEET`. Values are Bukkit `Material` names.
 - `commands`: executed as console; `%player%` is replaced with the fisher's name.

--- a/src/main/java/me/shreyjain/seaCreatures/creature/SeaCreatureDefinition.java
+++ b/src/main/java/me/shreyjain/seaCreatures/creature/SeaCreatureDefinition.java
@@ -14,6 +14,7 @@ public class SeaCreatureDefinition {
     private final String id;
     private final EntityType type;
     private final int weight;
+    private final int minLevel;
     private final boolean custom;
     private final String displayName; // legacy color codes supported
     private final boolean glowing;
@@ -31,6 +32,7 @@ public class SeaCreatureDefinition {
     public SeaCreatureDefinition(String id,
                                  EntityType type,
                                  int weight,
+                                 int minLevel,
                                  boolean custom,
                                  String displayName,
                                  boolean glowing,
@@ -47,6 +49,7 @@ public class SeaCreatureDefinition {
         this.id = id;
         this.type = type;
         this.weight = weight <= 0 ? 1 : weight;
+        this.minLevel = Math.max(minLevel, 0);
         this.custom = custom;
         this.displayName = displayName;
         this.glowing = glowing;
@@ -65,6 +68,7 @@ public class SeaCreatureDefinition {
     public String getId() { return id; }
     public EntityType getType() { return type; }
     public int getWeight() { return weight; }
+    public int getMinLevel() { return minLevel; }
     public boolean isCustom() { return custom; }
     public String getDisplayName() { return displayName; }
     public boolean isGlowing() { return glowing; }

--- a/src/main/java/me/shreyjain/seaCreatures/creature/SeaCreatureManager.java
+++ b/src/main/java/me/shreyjain/seaCreatures/creature/SeaCreatureManager.java
@@ -83,6 +83,7 @@ public class SeaCreatureManager {
         try { type = EntityType.valueOf(typeName.toUpperCase(Locale.ROOT)); }
         catch (Exception e) { log(Level.WARNING, "Unknown entity type '" + typeName + "' for id=" + id); return null; }
         int weight = asInt(map.get("weight"), 1);
+        int minLevel = asInt(map.get("min-level"), 1);
         boolean custom = asBool(map.get("custom"), false);
         String name = map.containsKey("display-name") ? String.valueOf(map.get("display-name")) : null;
         boolean glowing = asBool(map.get("glowing"), false);
@@ -168,7 +169,7 @@ public class SeaCreatureManager {
                 }
             }
         }
-        return new SeaCreatureDefinition(id, type, weight, custom, name, glowing, potionEffects, equipment, commands, minY, maxY, biomes, worlds, fishingXp, drops, replaceDefaultDrops);
+        return new SeaCreatureDefinition(id, type, weight, minLevel, custom, name, glowing, potionEffects, equipment, commands, minY, maxY, biomes, worlds, fishingXp, drops, replaceDefaultDrops);
     }
 
     private int asInt(Object o, int def) { return o instanceof Number n ? n.intValue() : parseInt(String.valueOf(o), def); }
@@ -183,7 +184,7 @@ public class SeaCreatureManager {
 
     public double computeChancePercent(int luckLevel) { double v = baseChancePercent + perLuckLevelBonus * luckLevel; return Math.max(0, Math.min(100, v)); }
 
-    public SeaCreatureDefinition pickRandom(Location loc) {
+    public SeaCreatureDefinition pickRandom(Location loc, int fishingLevel) {
         if (definitions.isEmpty()) return null;
         World world = loc.getWorld();
         int y = loc.getBlockY();
@@ -193,6 +194,7 @@ public class SeaCreatureManager {
             if (d.getMaxY() != null && y > d.getMaxY()) return false;
             if (d.getWorlds() != null && !d.getWorlds().contains(world.getName())) return false;
             if (d.getBiomes() != null && !d.getBiomes().contains(biome.name().toUpperCase(Locale.ROOT))) return false;
+            if (d.getMinLevel() > fishingLevel) return false;
             return true;
         }).toList();
         if (filtered.isEmpty()) return null;

--- a/src/main/java/me/shreyjain/seaCreatures/listener/FishingListener.java
+++ b/src/main/java/me/shreyjain/seaCreatures/listener/FishingListener.java
@@ -1,5 +1,8 @@
 package me.shreyjain.seaCreatures.listener;
 
+import dev.aurelium.auraskills.api.AuraSkillsApi;
+import dev.aurelium.auraskills.api.skill.Skills;
+import dev.aurelium.auraskills.api.user.SkillsUser;
 import me.shreyjain.seaCreatures.SeaCreatures;
 import me.shreyjain.seaCreatures.creature.SeaCreatureDefinition;
 import me.shreyjain.seaCreatures.creature.SeaCreatureManager;
@@ -33,6 +36,9 @@ public class FishingListener implements Listener {
     public void onFish(PlayerFishEvent event) {
         if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) return;
         Player player = event.getPlayer();
+        AuraSkillsApi skillsApi = AuraSkillsApi.get();
+        SkillsUser skillsUser = skillsApi.getUser(player.getUniqueId());
+        int userFishingLevel = skillsUser.getSkillLevel(Skills.FISHING);
 
         int luckLevel = 0;
         ItemStack rod = player.getInventory().getItemInMainHand();
@@ -45,7 +51,7 @@ public class FishingListener implements Listener {
         if (ThreadLocalRandom.current().nextDouble(100.0) > chance) return;
 
         Location spawnLoc = event.getHook().getLocation().clone();
-        SeaCreatureDefinition def = manager.pickRandom(spawnLoc);
+        SeaCreatureDefinition def = manager.pickRandom(spawnLoc, userFishingLevel);
         if (def == null) return;
 
         Entity caught = event.getCaught();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,7 @@ chance:
 #  id: unique string identifier (for logging / filtering)
 #  type: Bukkit EntityType name (required)
 #  weight: integer weight used for random selection (default 1)
+#  min-level: integer for minimum fishing level required for sea creature (default 0)
 #  min-y/max-y: optional world height constraints for spawning (inclusive)
 #  biomes: optional list of biome names restricting spawn
 #  worlds: optional list of world names restricting spawn
@@ -43,6 +44,7 @@ creatures:
   - id: DROWNED
     type: DROWNED
     weight: 10
+    min-level: 3
     fishing-xp: 400
     drops:
       replace-default: false
@@ -52,6 +54,7 @@ creatures:
   - id: GUARDIAN
     type: GUARDIAN
     weight: 5
+    min-level: 3
     fishing-xp: 500
     drops:
       replace-default: false
@@ -61,6 +64,7 @@ creatures:
   - id: ELDER_GUARDIAN
     type: ELDER_GUARDIAN
     weight: 1
+    min-level: 5
     fishing-xp: 1000
     drops:
       replace-default: true
@@ -71,6 +75,7 @@ creatures:
     type: GUARDIAN
     custom: true
     weight: 2
+    min-level: 7
     display-name: '&bElectric Guardian'
     glowing: true
     fishing-xp: 2500.0
@@ -92,6 +97,7 @@ creatures:
     type: DROWNED
     custom: true
     weight: 2
+    min-level: 7
     display-name: '&bElectric Drowned'
     glowing: true
     fishing-xp: 2200.0
@@ -111,6 +117,7 @@ creatures:
     type: DROWNED
     custom: true
     weight: 3
+    min-level: 7
     display-name: '&3Armored Drowned'
     fishing-xp: 2000.0
     equipment:


### PR DESCRIPTION
Added fishing level requirement, making certain sea creatures locked behind AuraSkills fishing level. 

Current Levels: 
 - Fish are available at any time.
 - Drowned & Regular Guardian at level 3.
 - Elder Guardian at level 5.
 - All special sea creatures at level 7.

Testing Done:
-  Ensured sea creature behavior did not change
-  Sea creatures that are locked behind certain levels do not spawn when under that level
-  Minimum level can be changed for each sea creature without affecting the others